### PR TITLE
Add flaky endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ An HTTP server with test methods for synthetic tests:
 * `GET /livecheck` returns 204 initially. `PUT /livecheck?code=newCode` changes this.
 `delay` argument can be provided which overrides the default five seconds that it waits before it performs the call.
 * `GET /sleep?delay=5` will return a 204 after five seconds.
+* `GET /flaky?code=503` will return a 503 on every other call, with 200 on the respective next call. The `code` can be omited, it will default to `502`.
 * `/ws` endpoint serves a websocket with an echo service that return everything that is send to it.

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+var toggle bool
+
 func main() {
 	ctx := context.Background()
 	signals := make(chan os.Signal, 1)
@@ -123,6 +125,26 @@ func main() {
 			} else {
 				w.WriteHeader(400)
 				return
+			}
+		})
+
+		http.HandleFunc("/flaky", func(w http.ResponseWriter, request *http.Request) {
+			toggle = !toggle
+
+			var httpStatusCode int = http.StatusBadGateway
+			if queryParameters := request.URL.Query(); queryParameters.Has("code") {
+				var err error
+				httpStatusCode, err = strconv.Atoi(queryParameters.Get("code"))
+				if err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+			}
+
+			if toggle {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(httpStatusCode)
 			}
 		})
 


### PR DESCRIPTION
Add `/flaky` endpoint, which will fail with a non `200` HTTP status code
on every second request, by default with `502`.
