### PR TITLE
Fix file read while using the GET method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 An HTTP server with test methods for synthetic tests:
 
 * `GET /` is a hello-world.
-* `GET /call-after-server-shutdown?url=https://someurl` returns a 204 and will cause the provided URL to be called after stopping the server. Optionally, a `delay` can be provided to override a wait time in seconds (default is 5s).
 * `GET /before-server-shutdown?url=https://someurl` returns a 204 and will cause the provided URL to be called when a SIGTERM signal is captured and before stopping the server. Optionally, a `delay` can be provided to override a wait time in seconds (default is 5s).
+* `GET /call-after-server-shutdown?url=https://someurl` returns a 204 and will cause the provided URL to be called after stopping the server. Optionally, a `delay` can be provided to override a wait time in seconds (default is 5s).
 * `PUT /claim-memory?amount=<bytes_count>` returns a 204 but before that creates a `byte[]` slice of the given length. If it goes oom, then it dies. ;-)
 * `GET /close` will cause the server to be shut down. Query parameters:
   * `delay` (default `0`) can be set to a positive number. The code will then wait the amount in seconds before the server is shut down.
@@ -17,6 +17,8 @@ An HTTP server with test methods for synthetic tests:
   * `iam` (default `https://iam.cloud.ibm.com`) allows to overwrite the IAM endpoint.
   * `profileName` specifies the name of the trusted profile.
 * `GET /env?env=someEnvKey` returns the value of an environment variable in the response body.
+* `GET /filesystem?path=<path>`, returns 200 with the file content if the path exists and is a file, 204 if it exists but is a directory, 404 if not found, and 500 for any other error.
+* `HEAD /filesystem?path=<path>`, returns 200 if the path exists and is a file, 204 if it exists but is a directory, 404 if not found, and 500 for any other error.
 * `GET /flaky?code=503` will return a 503 on every other call, with 200 on the respective next call. The `code` can be omitted, it will default to `502`.
 * `GET /livecheck` returns 204 initially. `PUT /livecheck?code=newCode` changes this.
 `delay` argument can be provided which overrides the default five seconds that it waits before it performs the call.

--- a/main.go
+++ b/main.go
@@ -452,6 +452,44 @@ func main() {
 			}
 		})
 
+		http.HandleFunc("/filesystem", func(w http.ResponseWriter, r *http.Request) {
+			queryParameters := r.URL.Query()
+			var path string
+			if queryParameters.Has("path") {
+				path = queryParameters.Get("path")
+			} else {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			fileInfo, err := os.Stat(path)
+			if os.IsNotExist(err) {
+				log.Printf("Path not found : %v", err)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			} else if err != nil {
+				log.Printf("Error checking path: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			if fileInfo.IsDir() {
+				w.WriteHeader(http.StatusNoContent)
+			} else {
+				w.Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
+				if r.Method == http.MethodGet {
+					data, err := os.ReadFile(path)
+					if err != nil {
+						log.Printf("Error reading file: %v", err)
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					log.Printf("File content length: %d", len(data))
+					w.Write(data)
+				}
+				w.WriteHeader(http.StatusOK)
+			}
+		})
+
 		http.Handle("/ws", websocket.Handler(func(ws *websocket.Conn) {
 			log.Printf("starting websocket handler for an echo service")
 


### PR DESCRIPTION
Fix file read while using the GET method

While reading the file using the GET method, we were getting the following error :
```
curl: (18) transfer closed with 62 bytes remaining to read
File content length: 85
```
and we found out that it was due to the `Content-Length` response header, so we added it only to the HEAD method.
